### PR TITLE
Fix template parts

### DIFF
--- a/template-parts/accolades.php
+++ b/template-parts/accolades.php
@@ -23,7 +23,7 @@ if ( $awards ) {
 						$award_alt = get_post_meta( $award, '_wp_attachment_image_alt', true );
 						$award     = is_int( $award ) ? wp_get_attachment_image( $award, 'full' ) : $award;
 						?>
-						<article class="accolade col-md align-items-md-center justify-content-md-center p-0" aria-label="Accolade <?php echo $award_alt; ?>">
+						<article class="accolade col-md align-items-md-center justify-content-md-center p-0" aria-label="Accolade <?php echo esc_attr( $award_alt ); ?>">
 							<?php echo wp_kses_post( $award ); ?>
 						</article>
 						<?php

--- a/template-parts/widgets.php
+++ b/template-parts/widgets.php
@@ -7,8 +7,8 @@
 
 // First two widgets.
 $columns = get_post_meta( get_the_ID(), '_columns', true );
-if ( empty( $columns ) ) {
-	get_theme_mod( 'why_choose' ) ? $columns[] = get_theme_mod( 'why_choose' ) : '';
+if ( empty( $columns ) && get_theme_mod( 'why_choose' ) ) {
+	$columns[] = get_theme_mod( 'why_choose' );
 }
 
 // Widget with border.


### PR DESCRIPTION
- Quick refactor of how the "Why Choose" column content is added to the array of columns. Makes it easier to read the code without the confusing ternary operator.
- Aria label in accolades template part needed the escape function for attributes.