### PR TITLE
Trailing slash network home URL of header logo

### DIFF
--- a/header.php
+++ b/header.php
@@ -32,7 +32,7 @@ $phone_number      = ! empty( trim( $page_phone_number ) ) ? $page_phone_number 
 		<div class="container">
 			<div class="row">
 				<div class="header__logo col-8">
-					<a class="d-block" href="<?php echo esc_url( network_home_url() ); ?>" rel="home"></a>
+					<a class="d-block" href="<?php echo esc_url( trailingslashit( network_home_url() ) ); ?>" rel="home"></a>
 				</div>
 
 				<?php if ( $phone_number ) { ?>


### PR DESCRIPTION
Due to best practice reasons, every URL should end with a trailing slash.
This removes the redirect from non-trailing slash URL -> trailing slash URL.

The functionality for adding the starter query parameter string to anchor links will also have the added benefit of a simpler check for URLs.