### PR TITLE
Fix path to images in the fixed CTA template

### DIFF
--- a/template-parts/fixed-cta.php
+++ b/template-parts/fixed-cta.php
@@ -17,12 +17,12 @@ $phone_number      = ! empty( trim( $page_phone_number ) ) ? $page_phone_number 
 	<div class="row p-4">
 		<div class="col-6">
 			<a href="tel:+1-<?php echo esc_attr( $phone_number ); ?>">
-				<img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/images/icon-phone.svg" alt="Phone Icon" />
+				<img src="<?php echo esc_url( get_template_directory_uri() ); ?>/images/icon-phone.svg" alt="Phone Icon" />
 			</a>
 		</div>
 		<div class="col-6">
 			<a href="#" id="chat-trigger">
-				<img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/images/icon-chat.svg" alt="Chat Icon" />
+				<img src="<?php echo esc_url( get_template_directory_uri() ); ?>/images/icon-chat.svg" alt="Chat Icon" />
 			</a>
 		</div>
 	</div>


### PR DESCRIPTION
The paths to the images in the fixed CTA template were using the function that targeted the child instead of parent theme.
When using a child theme (most of the time since this is specifically meant to be used as a parent theme), the URLs were pointing to the child theme, which is not the intended functionality.