### PR TITLE
feat: Add support for optimizelyEdge tracking

### DIFF
--- a/src/js/forms-tracking/optimizely-tracking.js
+++ b/src/js/forms-tracking/optimizely-tracking.js
@@ -1,36 +1,43 @@
-import { setInputValue } from '../theme/functions';
+/* global setInputValue */
 /**
  * Fetch the optimizely info we want to track and place it into our forms to track,
  * if the appropriate fields exist.
  */
 ( function( w ) {
 	// Check if optimizely is even present.
-	if ( 'undefined' === typeof w.optimizely ) {
+	if ( 'undefined' === typeof w.optimizely && 'undefined' === typeof w.optimizelyEdge ) {
 		return;
 	}
 
-	const activeCampaignStates = w.optimizely.get( 'state' ).getCampaignStates( {
-		isActive: true,
-	} );
+	// Get the experiments depending on which version is being used
+	// and then manipulate the returned object for use on our hand-off in our forms.
+	let activeExperiments = ( 'undefined' !== typeof w.optimizelyEdge ) ? w.optimizelyEdge.get( 'state' ).getActiveExperiments() : w.optimizely.get( 'state' ).getCampaignStates( { 'isActive': true } );
 
-	const activeCampaigns = [];
-
-	for ( const campaignId in activeCampaignStates ) {
-		const theCampaign = activeCampaignStates[ campaignId ];
-
-		activeCampaigns.push( theCampaign.experiment.id + '|' + theCampaign.variation.id );
-	}
+	activeExperiments = formatExperiments( activeExperiments );
 
 	const forms = document.querySelectorAll( 'form' );
 
-	if ( activeCampaigns.length > 0 && forms.length ) {
+	if ( activeExperiments.length > 0 && forms.length ) {
 		// Truncate the string since the systems we'll be sending this to have a character limit.
-		const optimizelyTrackString = activeCampaigns.join( ',' ).substring( 0, 255 );
+		const optimizelyTrackString = activeExperiments.join( ',' ).substring( 0, 255 );
 
 		for ( let formIndex = 0; formIndex < forms.length; formIndex++ ) {
 			const theForm = forms[ formIndex ];
 
 			setInputValue( '.track_optimizely', optimizelyTrackString, theForm );
 		}
+	}
+
+	function formatExperiments( fullObject ) {
+		const experimentsObject = [];
+
+		for ( let campaignId in fullObject ) {
+			let theCampaign = fullObject[ campaignId ];
+			const experimentId = theCampaign.experiment ? theCampaign.experiment.id : theCampaign.id;
+
+			experimentsObject.push( experimentId + '|' + theCampaign.variation.id );
+		}
+
+		return experimentsObject;
 	}
 } )( window );


### PR DESCRIPTION
We played with the idea of implementing [optimizelyEdge](https://docs.developers.optimizely.com/performance-edge/docs/overview) and although we won't be moving over to it quite yet, this would handle most of the lift.

Checks for both Optimizely Web and OptimizelyEdge but gives precedence to Optimizely Edge (the newer feature of the two).