### PR TITLE
perf: only preload most optimized fonts

### DIFF
--- a/inc/class-nusa-theme-setup.php
+++ b/inc/class-nusa-theme-setup.php
@@ -191,30 +191,16 @@ class NUSA_Theme_Setup {
 	 */
 	public function preload_fonts() {
 		?>
-		<link rel="preload" as="font" crossorigin="anonymous" href="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/fonts/fontello/fontello.eot?36463184">
-		<link rel="preload" as="font" crossorigin="anonymous" href="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/fonts/fontello/fontello.eot?36463184#iefix">
 		<link rel="preload" as="font" crossorigin="anonymous" href="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/fonts/fontello/fontello.woff2?36463184">
-		<link rel="preload" as="font" crossorigin="anonymous" href="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/fonts/fontello/fontello.woff?36463184">
-		<link rel="preload" as="font" crossorigin="anonymous" href="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/fonts/fontello/fontello.ttf?36463184">
-		<link rel="preload" as="font" crossorigin="anonymous" href="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/fonts/fontello/fontello.svg?36463184">
 		<link rel="preload" as="font" crossorigin="anonymous" href="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/fonts/open-sans/opensans-bold-webfont.woff2">
-		<link rel="preload" as="font" crossorigin="anonymous" href="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/fonts/open-sans/opensans-bold-webfont.woff">
 		<link rel="preload" as="font" crossorigin="anonymous" href="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/fonts/open-sans/opensans-extrabold-webfont.woff2">
-		<link rel="preload" as="font" crossorigin="anonymous" href="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/fonts/open-sans/opensans-extrabold-webfont.woff">
 		<link rel="preload" as="font" crossorigin="anonymous" href="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/fonts/open-sans/opensans-light-webfont.woff2">
-		<link rel="preload" as="font" crossorigin="anonymous" href="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/fonts/open-sans/opensans-light-webfont.woff">
 		<link rel="preload" as="font" crossorigin="anonymous" href="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/fonts/open-sans/opensans-regular-webfont.woff2">
-		<link rel="preload" as="font" crossorigin="anonymous" href="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/fonts/open-sans/opensans-regular-webfont.woff">
 		<link rel="preload" as="font" crossorigin="anonymous" href="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/fonts/open-sans/opensans-semibold-webfont.woff2">
-		<link rel="preload" as="font" crossorigin="anonymous" href="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/fonts/open-sans/opensans-semibold-webfont.woff">
 		<link rel="preload" as="font" crossorigin="anonymous" href="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/fonts/oswald/oswald-bold-webfont.woff2">
-		<link rel="preload" as="font" crossorigin="anonymous" href="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/fonts/oswald/oswald-bold-webfont.woff">
 		<link rel="preload" as="font" crossorigin="anonymous" href="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/fonts/oswald/oswald-heavy-webfont.woff2">
-		<link rel="preload" as="font" crossorigin="anonymous" href="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/fonts/oswald/oswald-heavy-webfont.woff">
 		<link rel="preload" as="font" crossorigin="anonymous" href="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/fonts/oswald/oswald-medium-webfont.woff2">
-		<link rel="preload" as="font" crossorigin="anonymous" href="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/fonts/oswald/oswald-medium-webfont.woff">
 		<link rel="preload" as="font" crossorigin="anonymous" href="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/fonts/oswald/oswald-regular-webfont.woff2">
-		<link rel="preload" as="font" crossorigin="anonymous" href="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/fonts/oswald/oswald-regular-webfont.woff">
 		<?php
 	}
 


### PR DESCRIPTION
We should really only be preloading the more optimized and modern versions of fonts instead of all fonts that _could_ be used.
This makes sure only the `. woff2` version of the fonts are preloaded.