### PR TITLE
gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,6 @@ cypress export-ignore
 cypress.json export-ignore
 README.md export-ignore
 utilities.sh export-ignore
+
+# Do not use diff when looking at built asset files, treating them as binary.
+assets/**/*.* -diff

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# git files
+.gitattributes export-ignore
+.gitignore export-ignore
+
+# source files
+.editorconfig export-ignore
+cypress export-ignore
+cypress.json export-ignore
+README.md export-ignore
+utilities.sh export-ignore


### PR DESCRIPTION
- Add files for `export-ignore` when packaging.
- Treat asset/built files as binary.