### PR TITLE
perf: preload fonts updates

### DIFF
--- a/inc/class-nusa-theme-setup.php
+++ b/inc/class-nusa-theme-setup.php
@@ -191,16 +191,16 @@ class NUSA_Theme_Setup {
 	 */
 	public function preload_fonts() {
 		?>
-		<link rel="preload" as="font" crossorigin="anonymous" href="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/fonts/fontello/fontello.woff2?36463184">
-		<link rel="preload" as="font" crossorigin="anonymous" href="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/fonts/open-sans/opensans-bold-webfont.woff2">
-		<link rel="preload" as="font" crossorigin="anonymous" href="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/fonts/open-sans/opensans-extrabold-webfont.woff2">
-		<link rel="preload" as="font" crossorigin="anonymous" href="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/fonts/open-sans/opensans-light-webfont.woff2">
-		<link rel="preload" as="font" crossorigin="anonymous" href="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/fonts/open-sans/opensans-regular-webfont.woff2">
-		<link rel="preload" as="font" crossorigin="anonymous" href="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/fonts/open-sans/opensans-semibold-webfont.woff2">
-		<link rel="preload" as="font" crossorigin="anonymous" href="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/fonts/oswald/oswald-bold-webfont.woff2">
-		<link rel="preload" as="font" crossorigin="anonymous" href="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/fonts/oswald/oswald-heavy-webfont.woff2">
-		<link rel="preload" as="font" crossorigin="anonymous" href="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/fonts/oswald/oswald-medium-webfont.woff2">
-		<link rel="preload" as="font" crossorigin="anonymous" href="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/fonts/oswald/oswald-regular-webfont.woff2">
+		<link rel="preload" as="font" crossorigin="anonymous" href="<?php echo esc_url( get_template_directory_uri() ); ?>/fonts/fontello/fontello.woff2?36463184">
+		<link rel="preload" as="font" crossorigin="anonymous" href="<?php echo esc_url( get_template_directory_uri() ); ?>/fonts/open-sans/opensans-bold-webfont.woff2">
+		<link rel="preload" as="font" crossorigin="anonymous" href="<?php echo esc_url( get_template_directory_uri() ); ?>/fonts/open-sans/opensans-extrabold-webfont.woff2">
+		<link rel="preload" as="font" crossorigin="anonymous" href="<?php echo esc_url( get_template_directory_uri() ); ?>/fonts/open-sans/opensans-light-webfont.woff2">
+		<link rel="preload" as="font" crossorigin="anonymous" href="<?php echo esc_url( get_template_directory_uri() ); ?>/fonts/open-sans/opensans-regular-webfont.woff2">
+		<link rel="preload" as="font" crossorigin="anonymous" href="<?php echo esc_url( get_template_directory_uri() ); ?>/fonts/open-sans/opensans-semibold-webfont.woff2">
+		<link rel="preload" as="font" crossorigin="anonymous" href="<?php echo esc_url( get_template_directory_uri() ); ?>/fonts/oswald/oswald-bold-webfont.woff2">
+		<link rel="preload" as="font" crossorigin="anonymous" href="<?php echo esc_url( get_template_directory_uri() ); ?>/fonts/oswald/oswald-heavy-webfont.woff2">
+		<link rel="preload" as="font" crossorigin="anonymous" href="<?php echo esc_url( get_template_directory_uri() ); ?>/fonts/oswald/oswald-medium-webfont.woff2">
+		<link rel="preload" as="font" crossorigin="anonymous" href="<?php echo esc_url( get_template_directory_uri() ); ?>/fonts/oswald/oswald-regular-webfont.woff2">
 		<?php
 	}
 


### PR DESCRIPTION
- Switch out the call `get_stylesheet_directory_uri()` to `get_template_directory_uri()` since this theme is used as a **parent** theme
- Addressing issue #162 